### PR TITLE
Problem: Cannot customize the et al. limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,15 @@ the example mappings for how to do this.
   let g:citation_vim_suffix="]"
   ```
 
-6. Set some mappings. Copy and paste the following examples into your vimrc to get started.
+6. Set the et al. limit. If the number of authors is greater than the limit only
+   the first author with `et al.` appended is shown or printed in case of
+   `citation/author`. (Default: 5)
+
+  ```vimscript
+  let g:citation_vim_et_al_limit=2
+  ```
+
+7. Set some mappings. Copy and paste the following examples into your vimrc to get started.
 
 
 ### Example mappings:

--- a/autoload/unite/sources/citation.vim
+++ b/autoload/unite/sources/citation.vim
@@ -1,6 +1,6 @@
 "=============================================================================
 " FILE: autoload/unite/source/citation.vim
-" AUTHOR:  Rafael Schouten <rafaelschouten@gmail.com>, 
+" AUTHOR:  Rafael Schouten <rafaelschouten@gmail.com>,
 " Forked From: unite-bibtex, Toshiki TERAMUREA
 " Last Modified: 8 Dec 2015.
 " License: MIT license  {{{
@@ -31,6 +31,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 call unite#util#set_default('g:citation_vim_mode', "zotero")
+call unite#util#set_default('g:citation_vim_et_al_limit', 5)
 call unite#util#set_default('g:citation_vim_collection', "")
 call unite#util#set_default('g:citation_vim_outer_prefix', "[")
 call unite#util#set_default('g:citation_vim_inner_prefix', "@")
@@ -156,8 +157,8 @@ endfunction
 " {{{ Build all sub_sources programatically.
 function! s:construct_sources(sub_sources)
       for sub_source in a:sub_sources
-          exec "let s:citation_source_" . sub_source . " = { 
-          \       'name': 'citation/" . sub_source . "', 
+          exec "let s:citation_source_" . sub_source . " = {
+          \       'name': 'citation/" . sub_source . "',
           \	      'default_action' : 'insert',
           \       'hooks': {},
           \       'syntax': 'uniteSource__citation',
@@ -171,8 +172,8 @@ function! s:construct_sources(sub_sources)
           exec "function! s:citation_source_" . sub_source . ".hooks.on_syntax(args, context)
           \  \n   call s:hooks.syntax()
           \  \n endfunction"
-          exec "function! s:citation_source_" . sub_source . ".gather_candidates(args,context) 
-          \  \n   return s:map_entries('citation','" . sub_source . "',a:args) 
+          exec "function! s:citation_source_" . sub_source . ".gather_candidates(args,context)
+          \  \n   return s:map_entries('citation','" . sub_source . "',a:args)
           \  \n endfunction"
           exec "function! s:citation_source_" . sub_source . ".action_table.preview.func(candidate)
           \  \n execute a:candidate.action__command
@@ -181,7 +182,7 @@ function! s:construct_sources(sub_sources)
 endfunction
 call s:construct_sources(s:sub_sources)
 
-function! s:map_entries(source, field, args) 
+function! s:map_entries(source, field, args)
     return map(s:get_source(a:source, a:field, a:args),'{
     \   "word": v:val[1],
     \   "source": a:source . "/" . a:field,
@@ -239,13 +240,13 @@ endfunction
 
 "-----------------------------------------------------------------------}}}
 " {{{ Return source and sub-sources to Unite.
-function! unite#sources#citation#define() 
+function! unite#sources#citation#define()
     let l:sources = [s:citation_source, s:citation_collection_source]
     for sub_source in s:sub_sources
         let l:sources += [s:citation_source_{sub_source}]
     endfor
     return l:sources
-endfunction 
+endfunction
 
 "-----------------------------------------------------------------------}}}
 " {{{ Syntax
@@ -263,13 +264,13 @@ function! s:hooks.syntax()
 
   execute "syntax region uniteSource__Citation_Text start=/[" . text . "]/ end=/[" . text . "]/
         \ contains=uniteSource__Citation_Field,uniteSource__Citation_Split
-        \ ,uniteSource__Citation_Arrow, uniteSource__Citation_Bar,uniteSource__Citation_Bracket   
+        \ ,uniteSource__Citation_Arrow, uniteSource__Citation_Bar,uniteSource__Citation_Bracket
         \ containedin=uniteSource__Citation"
   execute "syntax region uniteSource__Citation_Source start=/[" . source_field . "]/ end=/[" . source_field . "]/
 	 		        \ containedin=uniteSource__Citation"
-  execute 'syntax match uniteSource__Citation_Colon "\<\w*[' . colon . ']" 
+  execute 'syntax match uniteSource__Citation_Colon "\<\w*[' . colon . ']"
 			        \ contained containedin=uniteSource__Citation'
-  execute "syntax region uniteSource__Citation_Bracket start=/[" . bracket . "]/ end=/[" . bracket . "]/ 
+  execute "syntax region uniteSource__Citation_Bracket start=/[" . bracket . "]/ end=/[" . bracket . "]/
 			        \ containedin=uniteSource__Citation"
   execute "syntax region uniteSource__Citation_Arrow start=/[" . arrow . "]/ end=/[" . arrow . "]/
 			        \ containedin=uniteSource__Citation"

--- a/python/citation_vim/citation.py
+++ b/python/citation_vim/citation.py
@@ -33,13 +33,14 @@ class Citation(object):
 
         try:
             context.cache_path = os.path.expanduser(vim.eval("g:citation_vim_cache_path"))
-        except: 
+        except:
             raiseError(u"Citation.vim Error: global variable 'g:citation_vim_cache_path' is not set")
 
         context.collection   = vim.eval("g:citation_vim_collection")
         context.desc_format  = vim.eval("g:citation_vim_description_format")
         context.desc_fields  = vim.eval("g:citation_vim_description_fields")
         context.wrap_chars   = vim.eval("g:citation_vim_source_wrap")
+        context.et_al_limit  = vim.eval("g:citation_vim_et_al_limit")
         context.source       = vim.eval("a:source")
         context.source_field = vim.eval("a:field")
         searchkeys = vim.eval("l:searchkeys")
@@ -58,7 +59,7 @@ class Context(object):
 class Builder(object):
 
     def __init__(self, context, cache = True):
-        self.context = context 
+        self.context = context
         self.cache_file = os.path.join(self.context.cache_path, u"citation_vim_cache")
         self.cache = cache
 
@@ -70,7 +71,7 @@ class Builder(object):
             for item in self.get_items():
                 if self.context.collection == "" or self.context.collection in item.collections:
                     description = self.describe(item)
-                    output.append([getattr(item, self.context.source_field), 
+                    output.append([getattr(item, self.context.source_field),
                                    description,
                                    item.file,
                                    item.combined,
@@ -98,7 +99,7 @@ class Builder(object):
                 items = self.read_cache()
             except:
                 items = []
-            else:  
+            else:
                 return items
 
         items = parser.load()
@@ -123,7 +124,7 @@ class Builder(object):
                 return pickle.load(in_file)
         except Exception as e:
             raiseError(u"citation_vim.citation.write_cache(): %s" % e)
-        
+
     def write_cache(self, itemlist):
         try:
             with open(self.cache_file, 'wb') as out_file:

--- a/python/citation_vim/zotero/parser.py
+++ b/python/citation_vim/zotero/parser.py
@@ -15,11 +15,12 @@ class zoteroParser(object):
         self.context = context
         self.zotero_path = context.zotero_path
         self.cache_path = context.cache_path
+        self.et_al_limit = context.et_al_limit
 
     def load(self):
 
         """
-        Returns: 
+        Returns:
         A zotero database as an array of Items.
         """
 
@@ -73,7 +74,7 @@ class zoteroParser(object):
 
         if zot_item.authors == []:
             return ""
-        if len(zot_item.authors) > 5:
+        if len(zot_item.authors) > int(self.et_al_limit):
             return u"%s et al." % zot_item.authors[0][0]
         if len(zot_item.authors) > 2:
             auth_string = u""


### PR DESCRIPTION
Solution: Add a new attribute `g:citation:vim_et_al_limit` with
default value 5. If the number of authors is greater than the limit
only the first author with `et al.` is appended is shown or printed in
case of `citation/author`.