### PR TITLE
Fixing raiseError() function

### DIFF
--- a/python/citation_vim/bibtex/parser.py
+++ b/python/citation_vim/bibtex/parser.py
@@ -13,8 +13,7 @@ class BibtexParser(object):
         self.context = context
 
         if not check_path(self.context.bibtex_file):
-            raiseError(u"Citation.vim Error:", self.context.bibtex_file, \
-                    u" does not exist")
+            raiseError(u"{} does not exist".format(self.context.bibtex_file))
             return []
 
     def load(self):
@@ -27,7 +26,7 @@ class BibtexParser(object):
 
     def build_items(self, bib_data):
         items = []
-        
+
         for key in bib_data.entries:
             item = Item()
             item.collections  = []
@@ -75,7 +74,7 @@ class BibtexParser(object):
 
     def get_field(self, bib_entry, field):
         """
-        Returns cleaned field value for any bibtex field. 
+        Returns cleaned field value for any bibtex field.
         """
         output = bib_entry.fields[field] if field in bib_entry.fields else ""
         return self.strip_braces(output)
@@ -84,7 +83,7 @@ class BibtexParser(object):
         output = ""
         for field in fields:
             if field in bib_entry.fields:
-                output = bib_entry.fields[field] 
+                output = bib_entry.fields[field]
                 break
         return self.strip_braces(output)
 
@@ -106,7 +105,7 @@ class BibtexParser(object):
         """
         Returns: Authors - format depending on et_al_limit.
         """
-        if authors == []: 
+        if authors == []:
             return ""
         if len(authors) > self.context.et_al_limit:
             return u"%s et al." % authors[0][0]
@@ -166,5 +165,5 @@ class BibtexParser(object):
                 if len(split) == 4 and split.isdigit():
                     output = split
                     break
-        return output 
+        return output
 

--- a/python/citation_vim/utils.py
+++ b/python/citation_vim/utils.py
@@ -20,7 +20,7 @@ def decode_str(string):
 
 def is_current(file_path, cache_path):
     if not os.path.isfile(file_path):
-        raiseError(file_path, u"does not exist")
+        raiseError(u"{} does not exist".format(file_path))
     if not os.path.isfile(cache_path):
         return False
 
@@ -32,6 +32,5 @@ def check_path(path):
     path = os.path.abspath(os.path.expanduser(path))
     return os.path.exists(path)
 
-def raiseError(*args):
-    print(u"Citation.vim error:", *args)
-    raise RuntimeError(plug_error, args)
+def raiseError(message):
+    raise RuntimeError(u"Citation.vim error: " + message)

--- a/python/citation_vim/zotero/data.py
+++ b/python/citation_vim/zotero/data.py
@@ -141,7 +141,7 @@ class ZoteroData(object):
         """
         Returns filtered, complete items
         """
-        if not self.exists(): 
+        if not self.exists():
             return []
         self.filter_items()
         self.get_item_detail()
@@ -154,14 +154,14 @@ class ZoteroData(object):
         try:
             stats = os.stat(self.zotero_database)
         except Exception as e:
-            raiseError(u"citation_vim.zotero.data.exists(): %s" % e)
+            raiseError(u"citation_vim.zotero.data.exists(): {}".format(e))
             return False
         return True
 
 
     def filter_items(self):
         """
-        Populates self.index with new items, filtering out 
+        Populates self.index with new items, filtering out
         ignored types and unmatched searches
         """
         self.ignore_deleted()
@@ -214,7 +214,7 @@ class ZoteroData(object):
         query = self.build_fulltext_query()
         self.cur.execute(query)
         for [item_id] in self.cur.fetchall():
-            if not item_id in self.ignored: 
+            if not item_id in self.ignored:
                 self.fulltext_matches.append(item_id)
 
     def build_fulltext_query(self):
@@ -236,7 +236,7 @@ class ZoteroData(object):
         _froms = ''
         wheres = ''
         for i in range(len(self.context.searchkeys)):
-            if i > 0: 
+            if i > 0:
                 wheres += '\nand '
             searchkey = self.context.searchkeys[i].lower()
             _froms += fulltext_from.replace('#', str(i))
@@ -282,7 +282,7 @@ class ZoteroData(object):
         for [item_id, item_tag] in self.cur.fetchall():
             if item_id in self.index:
                 self.index[item_id].tags.append(item_tag)
-                
+
     def get_notes(self):
         """
         Adds notes arrays to self.index Items
@@ -339,6 +339,6 @@ class ZoteroData(object):
     def format_attachment_path(self, attachment_path):
         return os.path.join(self.attachment_base_path, attachment_path)
 
-    def attachment_has_right_extension(self, path): 
+    def attachment_has_right_extension(self, path):
         return path and os.path.splitext(path)[1] in self.attachment_extensions
 

--- a/python/citation_vim/zotero/parser.py
+++ b/python/citation_vim/zotero/parser.py
@@ -28,8 +28,7 @@ class ZoteroParser(object):
         A zotero database as an array of standardised Items.
         """
         if not check_path(os.path.join(self.zotero_path, u"zotero.sqlite")):
-            raiseError(u"Citation.vim Error:", self.zotero_path, \
-                    u"is not a valid zotero path")
+            raiseError(u"{} is not a valid zotero path".format(self.zotero_path))
             return []
         zotero = ZoteroData(self.context)
         zot_data = zotero.load()
@@ -69,7 +68,7 @@ class ZoteroParser(object):
     def clean(self, string):
         string = self.html_regex.sub('', string)
         return self.clean_regex.sub('', string)
-        
+
 
     def format_key(self, item, zot_item, citekeys):
         """
@@ -84,15 +83,15 @@ class ZoteroParser(object):
             author = zot_item.format_first_author().replace(" ", "_")
             replacements = {
                 u"title": title.lower(),
-                u"Title": title.capitalize(), 
-                u"author": author.lower(), 
+                u"Title": title.capitalize(),
+                u"author": author.lower(),
                 u"Author": author.capitalize(),
-                u"date": date.replace(' ', '-').capitalize() # Date may be 'In-press' 
+                u"date": date.replace(' ', '-').capitalize() # Date may be 'In-press'
             }
             key_format = u'%s' % self.context.key_format
             key = key_format.format(**replacements)
             key = self.context.key_clean_regex.sub("", key)
-            return key 
+            return key
         elif zot_item.id in citekeys:
             return citekeys[zot_item.id]
         else:


### PR DESCRIPTION
There was a undefined variable in `raiseError()` function in `python/citation_vim/ultis.py` and some instances of `raiseError()` are inconsistent in rest of the codebase.

This pull request changes the function to only one line where a string `message` is passed to `RuntimeError` with `Citation.vim error:` string appended to the `message` and changed all instances of `raiseError()` to accept one string. 
